### PR TITLE
Lazy load notebook content in the web reader

### DIFF
--- a/web/src/App.jsx
+++ b/web/src/App.jsx
@@ -117,7 +117,8 @@ function AppContent() {
   const [lang, setLang] = useState(() => getInitialLang())
   const [catalog, setCatalog] = useState(() => getCatalog(lang))
   const [currentId, setCurrentId] = useState(() => getInitialNotebookId())
-  const [loading] = useState(false)
+  const [notebook, setNotebook] = useState(null)
+  const [loading, setLoading] = useState(false)
   const [sidebarOpen, setSidebarOpen] = useState(() => getInitialSidebarOpen())
   const [tourActive, setTourActive] = useState(false)
   const [tourStepIndex, setTourStepIndex] = useState(0)
@@ -152,6 +153,43 @@ function AppContent() {
     window.localStorage.setItem('language', lang)
     writeLangToUrl(lang)
   }, [lang])
+
+  useEffect(() => {
+    let cancelled = false
+
+    if (!currentId || currentId === NOTES_SENTINEL) {
+      setNotebook(null)
+      setLoading(false)
+      return () => {
+        cancelled = true
+      }
+    }
+
+    setNotebook(null)
+    setLoading(true)
+
+    getNotebook(currentId, lang)
+      .then((nextNotebook) => {
+        if (!cancelled) {
+          setNotebook(nextNotebook)
+        }
+      })
+      .catch((error) => {
+        console.error(`Failed to load notebook ${currentId}`, error)
+        if (!cancelled) {
+          setNotebook(null)
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setLoading(false)
+        }
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [currentId, lang])
 
   useEffect(() => {
     const syncFromHash = () => {
@@ -204,7 +242,6 @@ function AppContent() {
   }, [lang])
 
   const currentMeta = catalog.find(n => n.id === currentId)
-  const notebook = currentId ? getNotebook(currentId, lang) : null
   const tourNotebookId = catalog.find(n => n.id === '01-tokenizer-basics')?.id || catalog[0]?.id
   const tourCopy = {
     zh: [

--- a/web/src/data/notebooks.js
+++ b/web/src/data/notebooks.js
@@ -1,15 +1,14 @@
 import katex from 'katex'
+import { NOTEBOOK_CATALOG } from 'virtual:notebook-catalog'
 
 const zhNotebookModules = import.meta.glob('../../../notebooks/**/*.ipynb', {
   query: '?raw',
   import: 'default',
-  eager: true,
 })
 
 const enNotebookModules = import.meta.glob('../../../notebooks-en/**/*.ipynb', {
   query: '?raw',
   import: 'default',
-  eager: true,
 })
 
 const PARTS = [
@@ -60,44 +59,27 @@ function normalizeLang(lang) {
   return lang === 'en' ? 'en' : 'zh'
 }
 
-function stripMarkdownInline(value) {
-  return String(value)
-    .replace(/^#+\s*/, '')
-    .replace(/\s+#+$/, '')
-    .replace(/\*\*([^*]+)\*\*/g, '$1')
-    .replace(/\*([^*]+)\*/g, '$1')
-    .replace(/`([^`]+)`/g, '$1')
-    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
-    .trim()
+function titleFromId(id) {
+  return id
+    .replace(/^\d+-/, '')
+    .split('-')
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(' ')
 }
 
-function getNotebookTitle(raw, fallback) {
-  try {
-    const nb = JSON.parse(raw)
-    for (const cell of nb.cells || []) {
-      if (cell.cell_type !== 'markdown') continue
-      const source = normalizeSource(cell.source)
-      const heading = source.match(/^#\s+(.+)$/m)
-      if (heading) return stripMarkdownInline(heading[1])
-    }
-  } catch {
-    // Invalid notebooks are ignored here; the viewer will fail visibly when opened.
-  }
-  return fallback
-}
-
-function buildNotebookEntries(modules, rootDir) {
+function buildNotebookEntries(modules, rootDir, lang) {
   return Object.entries(modules)
-  .map(([path, raw]) => {
+  .map(([path, load]) => {
     const match = path.match(new RegExp(`${rootDir}/([^/]+)/([^/]+)\\.ipynb$`))
     if (!match) return null
     const [, partDir, id] = match
     return {
       id,
       partDir,
-      raw,
+      load,
       order: PARTS.findIndex(([dir]) => dir === partDir),
-      title: getNotebookTitle(raw, id),
+      title: NOTEBOOK_CATALOG[lang]?.[id]?.title || titleFromId(id),
     }
   })
   .filter(Boolean)
@@ -108,8 +90,8 @@ function buildNotebookEntries(modules, rootDir) {
 }
 
 const NOTEBOOKS_BY_LANG = {
-  zh: buildNotebookEntries(zhNotebookModules, 'notebooks'),
-  en: buildNotebookEntries(enNotebookModules, 'notebooks-en'),
+  zh: buildNotebookEntries(zhNotebookModules, 'notebooks', 'zh'),
+  en: buildNotebookEntries(enNotebookModules, 'notebooks-en', 'en'),
 }
 
 function escapeHtml(value) {
@@ -652,9 +634,9 @@ function renderNotebook(nb, lang = 'zh') {
     .join('\n')
 }
 
-function parseNotebook(entry, lang = 'zh') {
+function parseNotebook(entry, raw, lang = 'zh') {
   const safeLang = normalizeLang(lang)
-  const nb = JSON.parse(entry.raw)
+  const nb = JSON.parse(raw)
   const part = PARTS.find(([dir]) => dir === entry.partDir)?.[1] || entry.partDir
   return {
     id: entry.id,
@@ -679,10 +661,12 @@ export function getCatalog(lang = 'zh') {
   })
 }
 
-export function getNotebook(id, lang = 'zh') {
+export async function getNotebook(id, lang = 'zh') {
   const safeLang = normalizeLang(lang)
   const entry = NOTEBOOKS_BY_LANG[safeLang].find(item => item.id === id)
-  return entry ? parseNotebook(entry, safeLang) : null
+  if (!entry) return null
+  const raw = await entry.load()
+  return parseNotebook(entry, raw, safeLang)
 }
 
 if (import.meta.hot) {

--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -2,6 +2,101 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import { execSync } from 'child_process'
+import { existsSync, readdirSync, readFileSync } from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const repoRoot = fileURLToPath(new URL('..', import.meta.url))
+
+function normalizeNotebookSource(source) {
+  return Array.isArray(source) ? source.join('') : source || ''
+}
+
+function stripMarkdownInline(value) {
+  return String(value)
+    .replace(/^#+\s*/, '')
+    .replace(/\s+#+$/, '')
+    .replace(/\*\*([^*]+)\*\*/g, '$1')
+    .replace(/\*([^*]+)\*/g, '$1')
+    .replace(/`([^`]+)`/g, '$1')
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, '$1')
+    .trim()
+}
+
+function getNotebookTitle(filePath, fallback) {
+  try {
+    const nb = JSON.parse(readFileSync(filePath, 'utf-8'))
+    for (const cell of nb.cells || []) {
+      if (cell.cell_type !== 'markdown') continue
+      const source = normalizeNotebookSource(cell.source)
+      const heading = source.match(/^#\s+(.+)$/m)
+      if (heading) return stripMarkdownInline(heading[1])
+    }
+  } catch {
+    // Invalid notebooks should fail visibly in the viewer when opened.
+  }
+  return fallback
+}
+
+function listNotebookFiles(dir) {
+  if (!existsSync(dir)) return []
+
+  const entries = readdirSync(dir, { withFileTypes: true })
+  return entries.flatMap((entry) => {
+    const entryPath = path.join(dir, entry.name)
+    if (entry.isDirectory()) return listNotebookFiles(entryPath)
+    return entry.isFile() && entry.name.endsWith('.ipynb') ? [entryPath] : []
+  })
+}
+
+function buildNotebookCatalogFor(rootDir) {
+  const catalog = {}
+  const baseDir = path.join(repoRoot, rootDir)
+
+  for (const filePath of listNotebookFiles(baseDir)) {
+    const rel = path.relative(baseDir, filePath).replaceAll(path.sep, '/')
+    const match = rel.match(/^([^/]+)\/([^/]+)\.ipynb$/)
+    if (!match) continue
+    const [, partDir, id] = match
+    catalog[id] = {
+      partDir,
+      title: getNotebookTitle(filePath, id),
+    }
+  }
+
+  return catalog
+}
+
+function buildNotebookCatalog() {
+  return {
+    zh: buildNotebookCatalogFor('notebooks'),
+    en: buildNotebookCatalogFor('notebooks-en'),
+  }
+}
+
+function notebookCatalogPlugin() {
+  const virtualModuleId = 'virtual:notebook-catalog'
+  const resolvedVirtualModuleId = '\0' + virtualModuleId
+
+  return {
+    name: 'vite-plugin-notebook-catalog',
+    resolveId(id) {
+      if (id === virtualModuleId) return resolvedVirtualModuleId
+    },
+    buildStart() {
+      for (const filePath of [
+        ...listNotebookFiles(path.join(repoRoot, 'notebooks')),
+        ...listNotebookFiles(path.join(repoRoot, 'notebooks-en')),
+      ]) {
+        this.addWatchFile(filePath)
+      }
+    },
+    load(id) {
+      if (id !== resolvedVirtualModuleId) return
+      return `export const NOTEBOOK_CATALOG = ${JSON.stringify(buildNotebookCatalog())}`
+    },
+  }
+}
 
 function changelogPlugin() {
   const virtualModuleId = 'virtual:changelog'
@@ -33,7 +128,7 @@ function changelogPlugin() {
 }
 
 export default defineConfig({
-  plugins: [react(), tailwindcss(), changelogPlugin()],
+  plugins: [react(), tailwindcss(), notebookCatalogPlugin(), changelogPlugin()],
   define: {
     __CHANGELOG_COMMITS__: (() => {
       try {
@@ -57,6 +152,9 @@ export default defineConfig({
     host: '127.0.0.1',
     port: 5173,
     strictPort: false,
+    fs: {
+      allow: [repoRoot],
+    },
   },
   build: {
     outDir: '../docs',


### PR DESCRIPTION
## Summary
- lazy-load notebook raw content instead of bundling every `.ipynb` into the initial app chunk
- generate a lightweight notebook catalog from notebook headings at Vite build/dev time
- load selected notebooks asynchronously and preserve the existing loading state

## Why
The web reader previously imported all notebook raw content eagerly, which made the initial JS bundle very large. This change keeps the catalog lightweight while moving notebook bodies into on-demand chunks.

## Validation
- npm run build
- verified Chinese deep link `#01-tokenizer-basics`
- verified English deep link `?lang=en#26-rag`

In a local production build, the initial JS chunk dropped from about 5,387 kB / gzip 2,363 kB to about 616 kB / gzip 184 kB.